### PR TITLE
3 refactor watchlist index

### DIFF
--- a/CLAUSES/ccl_clausefunc.c
+++ b/CLAUSES/ccl_clausefunc.c
@@ -535,7 +535,7 @@ long ClauseSetDeleteOrphans(ClauseSet_p set)
    Clause_p handle;
 
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = set->anchor->succ;
    while(handle != set->anchor)

--- a/CLAUSES/ccl_clauseset_indexes.h
+++ b/CLAUSES/ccl_clauseset_indexes.h
@@ -41,8 +41,12 @@ typedef struct clauseset_indexes
 /*---------------------------------------------------------------------*/
 
 ClausesetIndexes_p ClausesetIndexesAlloc();
+void ClausesetIndexInsertNewClause(ClausesetIndexes_p clauseset_indexes, FVPackedClause_p newclause);
+Clause_p ClausesetIndexExtractEntry(ClausesetIndexes_p clauseset_indexes, Clause_p junk);
 void ClausesetIndexesFree(ClausesetIndexes_p clauseset_indexes);
+void ClausesetIndexesUCIndexededInsert(ClausesetIndexes_p clauseset_indexes, Clause_p newclause);
 void ClausesetIndexesPDTIndexedInsert(ClausesetIndexes_p clauseset_indexes, Clause_p newclause);
+
 
 /*---------------------------------------------------------------------*/
 /*                         Internal Functions                          */
@@ -50,6 +54,8 @@ void ClausesetIndexesPDTIndexedInsert(ClausesetIndexes_p clauseset_indexes, Clau
 
 ClausesetIndexes_p ClausesetIndexesAllocRaw();
 void ClausesetIndexesFreeRaw(ClausesetIndexes_p clauseset_indexes);
+void ClausesetIndexesPDTDelteClause(ClausesetIndexes_p clauseset_indexes, 
+                                    Clause_p junk);
 
 /*---------------------------------------------------------------------*/
 /*                        End of File                                  */

--- a/CLAUSES/ccl_clausesets.c
+++ b/CLAUSES/ccl_clausesets.c
@@ -326,7 +326,7 @@ ClauseSet_p ClauseSetAlloc(void)
    handle->anchor->pred = handle->anchor->succ = handle->anchor;
    handle->date = SysDateCreationTime();
    SysDateInc(&handle->date);
-   handle->clauseset_indexes = ClausesetIndexesAlloc();
+   // handle->clauseset_indexes = ClausesetIndexesAlloc();
 
    handle->eval_indices = PDArrayAlloc(4,4);
    handle->eval_no = 0;
@@ -380,10 +380,10 @@ void ClauseSetFree(ClauseSet_p junk)
    assert(junk);
 
    ClauseSetFreeClauses(junk);
-   if(junk->clauseset_indexes)
-   {
-      ClausesetIndexesFree(junk->clauseset_indexes);
-   }
+   // if(junk->clauseset_indexes)
+   // {
+   //    ClausesetIndexesFree(junk->clauseset_indexes);
+   // }
 
    PDArrayFree(junk->eval_indices);
    ClauseCellFree(junk->anchor);
@@ -532,11 +532,32 @@ long ClauseSetInsertSet(ClauseSet_p set, ClauseSet_p from)
 
 void ClauseSetPDTIndexedInsert(ClauseSet_p set, Clause_p newclause)
 {
+   // assert(ClauseIsUnit(newclause));
+
+   // ClauseSetInsert(set, newclause);
+   // ClausesetIndexInsertNewClause(set->clauseset_indexes, newclause);
+   ClausePos_p pos;
+
+   assert(set->demod_index);
    assert(ClauseIsUnit(newclause));
 
    ClauseSetInsert(set, newclause);
-   ClausesetIndexesPDTIndexedInsert(set->clauseset_indexes, newclause);
-   
+   pos          = ClausePosCellAlloc();
+   pos->clause  = newclause;
+   pos->literal = newclause->literals;
+   pos->side    = LeftSide;
+   pos->pos     = NULL;
+   PDTreeInsert(set->demod_index, pos);
+   if(!EqnIsOriented(newclause->literals))
+   {
+      pos          = ClausePosCellAlloc();
+      pos->clause  = newclause;
+      pos->literal = newclause->literals;
+      pos->side    = RightSide;
+      pos->pos     = NULL;
+      PDTreeInsert(set->demod_index, pos);
+   }
+
    ClauseSetProp(newclause, CPIsDIndexed);
 }
 
@@ -557,7 +578,7 @@ void ClauseSetPDTIndexedInsert(ClauseSet_p set, Clause_p newclause)
 
 void ClauseSetIndexedInsert(ClauseSet_p set, FVPackedClause_p newclause)
 {
-   if(!set->clauseset_indexes->demod_index)
+   if(!set->demod_index)
    {
       ClauseSetInsert(set, newclause->clause);
    }
@@ -565,9 +586,13 @@ void ClauseSetIndexedInsert(ClauseSet_p set, FVPackedClause_p newclause)
    {
       ClauseSetPDTIndexedInsert(set, newclause->clause);
    }
-   if(set->clauseset_indexes->fvindex)
+   // if(set->clauseset_indexes)
+   // {
+   //    ClausesetIndexInsertNewClause(set->clauseset_indexes, newclause);  
+   // }
+   if(set->fvindex)
    {
-      FVIndexInsert(set->clauseset_indexes->fvindex, newclause);
+      FVIndexInsert(set->fvindex, newclause);
       ClauseSetProp(newclause->clause, CPIsSIndexed);
    }
 }
@@ -588,7 +613,7 @@ void ClauseSetIndexedInsert(ClauseSet_p set, FVPackedClause_p newclause)
 
 void ClauseSetIndexedInsertClause(ClauseSet_p set, Clause_p newclause)
 {
-   FVPackedClause_p pclause = FVIndexPackClause(newclause, set->clauseset_indexes->fvindex);
+   FVPackedClause_p pclause = FVIndexPackClause(newclause, set->fvindex);
    assert(newclause->weight == ClauseStandardWeight(newclause));
    ClauseSetIndexedInsert(set, pclause);
    FVUnpackClause(pclause);
@@ -637,21 +662,20 @@ Clause_p ClauseSetExtractEntry(Clause_p clause)
 {
    assert(clause);
    assert(clause->set);
-   assert(clause->set->clauseset_indexes);
 
    /* ClausePCLPrint(stdout, clause, true); */
 
    if(ClauseQueryProp(clause, CPIsDIndexed))
    {
-      assert(clause->set->clauseset_indexes->demod_index);
-      if(clause->set->clauseset_indexes->demod_index)
+      assert(clause->set->demod_index);
+      if(clause->set->demod_index)
       {
          assert(ClauseIsUnit(clause));
-         PDTreeDelete(clause->set->clauseset_indexes->demod_index, clause->literals->lterm,
+         PDTreeDelete(clause->set->demod_index, clause->literals->lterm,
                       clause);
          if(!EqnIsOriented(clause->literals))
          {
-            PDTreeDelete(clause->set->clauseset_indexes->demod_index,
+            PDTreeDelete(clause->set->demod_index,
                          clause->literals->rterm, clause);
          }
          ClauseDelProp(clause, CPIsDIndexed);
@@ -659,7 +683,8 @@ Clause_p ClauseSetExtractEntry(Clause_p clause)
    }
    if(ClauseQueryProp(clause, CPIsSIndexed))
    {
-      FVIndexDelete(clause->set->clauseset_indexes->fvindex, clause);
+      // ClausesetIndexExtractEntry(clause->set->clauseset_indexes, clause);
+      FVIndexDelete(clause->set->fvindex, clause);
       ClauseDelProp(clause, CPIsSIndexed);
    }
    clause_set_extract_entry(clause);
@@ -1073,7 +1098,7 @@ long ClauseSetDeleteNonUnits(ClauseSet_p set)
    Clause_p handle;
 
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = set->anchor->succ;
    while(handle != set->anchor)
@@ -1449,7 +1474,7 @@ long ClauseSetFilterTrivial(ClauseSet_p set)
    long count = 0;
 
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = set->anchor->succ;
    while(handle != set->anchor)
@@ -1488,7 +1513,7 @@ long ClauseSetFilterTautologies(ClauseSet_p set, TB_p work_bank)
    long count = 0;
 
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = set->anchor->succ;
    while(handle != set->anchor)
@@ -2130,11 +2155,12 @@ PermVector_p PermVectorCompute(ClauseSet_p set, FVCollect_p cspec,
 
 long ClauseSetFVIndexify(ClauseSet_p set)
 {
+   // TODO: This now covers the hole clauseset_index
    PStack_p stack = PStackAlloc();
    Clause_p clause;
 
    assert(set);
-   assert(set->clauseset_indexes->fvindex);
+   assert(set->fvindex);
 
    while((clause = ClauseSetExtractFirst(set)))
    {
@@ -2148,6 +2174,25 @@ long ClauseSetFVIndexify(ClauseSet_p set)
    }
    PStackFree(stack);
    return set->members;
+
+   // PStack_p stack = PStackAlloc();
+   // Clause_p clause;
+
+   // assert(set);
+   // assert(set->clauseset_indexes);
+
+   // while((clause = ClauseSetExtractFirst(set)))
+   // {
+   //    PStackPushP(stack, clause);
+   // }
+   // while(!PStackEmpty(stack))
+   // {
+   //    clause = PStackPopP(stack);
+   //    assert(clause->weight == ClauseStandardWeight(clause));
+   //    ClauseSetIndexedInsertClause(set, clause);
+   // }
+   // PStackFree(stack);
+   // return set->members;
 }
 
 

--- a/CLAUSES/ccl_clausesets.h
+++ b/CLAUSES/ccl_clausesets.h
@@ -47,7 +47,8 @@ typedef struct clausesetcell
           rewriting. The special date SysCreationDate()
           is used to indicate ignoring of dates when
           checking for irreducability. */
-   ClausesetIndexes_p clauseset_indexes;
+   PDTree_p  demod_index; /* If used for demodulators */
+   FVIAnchor_p fvindex; /* Used for non-unit subsumption */
    PDArray_p eval_indices;
    long      eval_no;
    DStr_p     identifier;
@@ -67,8 +68,8 @@ typedef struct clausesetcell
 #define     ClauseSetStorage(set)\
             (((CLAUSECELL_DYN_MEM+EVAL_MEM((set)->eval_no))*(set)->members+\
             EQN_CELL_MEM*(set)->literals)+\
-            PDTreeStorage(set->clauseset_indexes->demod_index)+\
-       FVIndexStorage(set->clauseset_indexes->fvindex))
+            PDTreeStorage(set->demod_index)+\
+            FVIndexStorage(set->fvindex))
 
 ClauseSet_p ClauseSetAlloc(void);
 void        ClauseSetFreeClauses(ClauseSet_p set);

--- a/CLAUSES/ccl_global_indices.c
+++ b/CLAUSES/ccl_global_indices.c
@@ -85,7 +85,8 @@ void GlobalIndicesInit(GlobalIndices_p indices,
                        Sig_p sig,
                        char* rw_bw_index_type,
                        char* pm_from_index_type,
-                       char* pm_into_index_type)
+                       char* pm_into_index_type,
+                       char* unitclause_index_type)
 {
    FPIndexFunction indexfun;
 
@@ -115,6 +116,12 @@ void GlobalIndicesInit(GlobalIndices_p indices,
    if(indexfun)
    {
       indices->pm_negp_index = FPIndexAlloc(indexfun, sig, SubtermOLTreeFreeWrapper);
+   }
+   indexfun = GetFPIndexFunction(unitclause_index_type);
+   strcpy(indices->unitclause_index_type, unitclause_index_type);
+   if (indexfun)
+   {
+      indices->unitclause_index = FPIndexAlloc(indexfun, sig, UnitclauseIndexFreeWrapper);
    }
 }
 
@@ -153,6 +160,11 @@ void GlobalIndicesFreeIndices(GlobalIndices_p indices)
       FPIndexFree(indices->pm_negp_index);
       indices->pm_negp_index = NULL;
    }
+   if(indices->unitclause_index)
+   {
+      FPIndexFree(indices->unitclause_index);
+      indices->unitclause_index = NULL;
+   }
 }
 
 
@@ -176,7 +188,8 @@ void GlobalIndicesReset(GlobalIndices_p indices)
                      indices->sig,
                      indices->rw_bw_index_type,
                      indices->pm_from_index_type,
-                     indices->pm_into_index_type);
+                     indices->pm_into_index_type,
+                     indices->unitclause_index_type);
 }
 
 
@@ -221,6 +234,11 @@ void GlobalIndicesInsertClause(GlobalIndices_p indices, Clause_p clause)
       PERF_CTR_ENTRY(PMIndexTimer);
       OverlapIndexInsertFromClause(indices->pm_from_index, clause);
       PERF_CTR_EXIT(PMIndexTimer);
+   }
+   if(indices->unitclause_index)
+   {
+      // TODO: PERF_CTR_ENTRY
+      UnitclauseIndexInsertClause(indices->unitclause_index, clause);  
    }
 }
 
@@ -267,6 +285,11 @@ void GlobalIndicesDeleteClause(GlobalIndices_p indices, Clause_p clause)
       PERF_CTR_ENTRY(PMIndexTimer);
       OverlapIndexDeleteFromClause(indices->pm_from_index, clause);
       PERF_CTR_EXIT(PMIndexTimer);
+   }
+   if(indices->unitclause_index)
+   {
+      // TODO: PERF_CTR_ENTRY
+      UnitclauseIndexDeleteClause(indices->unitclause_index, clause);
    }
    // printf("# ...GlobalIndicesDeleteClause()\n");
 }

--- a/CLAUSES/ccl_global_indices.h
+++ b/CLAUSES/ccl_global_indices.h
@@ -27,6 +27,7 @@ Changes
 
 #include <ccl_subterm_index.h>
 #include <ccl_overlap_index.h>
+#include <ccl_unitclause_index.h>
 #include <ccl_clausesets.h>
 
 
@@ -41,11 +42,13 @@ typedef struct global_indices_cell
    char              pm_from_index_type[MAX_PM_INDEX_NAME_LEN];
    char              pm_into_index_type[MAX_PM_INDEX_NAME_LEN];
    char              pm_negp_index_type[MAX_PM_INDEX_NAME_LEN];
+   char              unitclause_index_type[MAX_PM_INDEX_NAME_LEN];
    Sig_p             sig;
    SubtermIndex_p    bw_rw_index;
    OverlapIndex_p    pm_from_index;
    OverlapIndex_p    pm_into_index;
    OverlapIndex_p    pm_negp_index;
+   UnitclauseIndex_p unitclause_index;
 }GlobalIndices, *GlobalIndices_p;
 
 
@@ -62,7 +65,8 @@ void GlobalIndicesInit(GlobalIndices_p indices,
                        Sig_p sig,
                        char* rw_bw_index_type,
                        char* pm_from_index_type,
-                       char* pm_into_index_type);
+                       char* pm_into_index_type,
+                       char* unitclause_index_type);
 
 void GlobalIndicesFreeIndices(GlobalIndices_p indices);
 void GlobalIndicesReset(GlobalIndices_p indices);

--- a/CLAUSES/ccl_proofstate.c
+++ b/CLAUSES/ccl_proofstate.c
@@ -170,9 +170,9 @@ ProofState_p ProofStateAlloc(FunctionProperties free_symb_prop)
    GlobalIndicesNull(&(handle->gindices));
    handle->fvi_initialized      = false;
    handle->fvi_cspec            = NULL;
-   handle->processed_pos_rules->clauseset_indexes->demod_index = PDTreeAlloc(handle->terms);
-   handle->processed_pos_eqns->clauseset_indexes->demod_index  = PDTreeAlloc(handle->terms);
-   handle->processed_neg_units->clauseset_indexes->demod_index = PDTreeAlloc(handle->terms);
+   handle->processed_pos_rules->demod_index = PDTreeAlloc(handle->terms);
+   handle->processed_pos_eqns->demod_index  = PDTreeAlloc(handle->terms);
+   handle->processed_neg_units->demod_index = PDTreeAlloc(handle->terms);
    handle->demods[0]            = handle->processed_pos_rules;
    handle->demods[1]            = handle->processed_pos_eqns;
    handle->demods[2]            = NULL;
@@ -339,7 +339,6 @@ void ProofStateInitWatchlist(ProofState_p state, OCB_p ocb)
          handle = ClauseSetExtractFirst(state->watchlist);
          ClauseSetInsert(tmpset, handle);
       }
-      // TODO: The PDTIndex for Unitclauses shall be constructed somwehere here.
       // TODO: Determine how to identify unit clauses and how to handle them.
       ClauseSetIndexedInsertClauseSet(state->watchlist, tmpset);
       ClauseSetFree(tmpset);
@@ -714,8 +713,8 @@ void ProofStateStatisticsPrint(FILE* out, ProofState_p state)
       fprintf(out,
               "# Match attempts with oriented units   : %lu\n"
               "# Match attempts with unoriented units : %lu\n",
-              state->processed_pos_rules->clauseset_indexes->demod_index->match_count,
-              state->processed_pos_eqns->clauseset_indexes->demod_index->match_count);
+              state->processed_pos_rules->demod_index->match_count,
+              state->processed_pos_eqns->demod_index->match_count);
 #ifdef MEASURE_EXPENSIVE
       fprintf(out,
               "# Oriented PDT nodes visited           : %lu\n"

--- a/CLAUSES/ccl_rewrite.c
+++ b/CLAUSES/ccl_rewrite.c
@@ -484,16 +484,16 @@ MatchRes_p indexed_find_demodulator(OCB_p ocb, Term_p term,
 
    assert(term);
    assert(demodulators);
-   assert(demodulators->clauseset_indexes->demod_index);
+   assert(demodulators->demod_index);
    assert(term->weight ==
             TermWeight(term, DEFAULT_VWEIGHT, DEFAULT_FWEIGHT));
    assert(!TermIsTopRewritten(term));
 
    RewriteAttempts++;
 
-   PDTreeSearchInit(demodulators->clauseset_indexes->demod_index, term, date, prefer_general);
+   PDTreeSearchInit(demodulators->demod_index, term, date, prefer_general);
 
-   while((match_info = PDTreeFindNextDemodulator(demodulators->clauseset_indexes->demod_index, subst)))
+   while((match_info = PDTreeFindNextDemodulator(demodulators->demod_index, subst)))
    {
       pos = match_info->pos;
       eqn = pos->literal;
@@ -544,7 +544,7 @@ MatchRes_p indexed_find_demodulator(OCB_p ocb, Term_p term,
       }
       MatchResFree(match_info);
    }
-   PDTreeSearchExit(demodulators->clauseset_indexes->demod_index);
+   PDTreeSearchExit(demodulators->demod_index);
 
 #ifndef NDEBUG
    if(match_info
@@ -590,7 +590,7 @@ static Term_p rewrite_with_clause_set(OCB_p ocb, TB_p bank, Term_p term,
    MatchRes_p mi;
    Term_p      repl;
 
-   assert(demodulators->clauseset_indexes->demod_index);
+   assert(demodulators->demod_index);
    assert(term);
    assert(!TermIsVar(term));
    assert(!TermIsTopRewritten(term));

--- a/CLAUSES/ccl_subsumption.c
+++ b/CLAUSES/ccl_subsumption.c
@@ -1443,9 +1443,9 @@ Clause_p ClauseSetSubsumesFVPackedClause(ClauseSet_p set,
    PERF_CTR_ENTRY(SetSubsumeTimer);
    assert(sub_candidate->clause->weight == ClauseStandardWeight(sub_candidate->clause));
 
-   if(set->clauseset_indexes->fvindex && sub_candidate->array)
+   if(set->fvindex && sub_candidate->array)
    {
-      res = clause_set_subsumes_clause_indexed(set->clauseset_indexes->fvindex->index,
+      res = clause_set_subsumes_clause_indexed(set->fvindex->index,
                                                sub_candidate, 0);
       PERF_CTR_EXIT(SetSubsumeTimer);
       return res;
@@ -1475,12 +1475,12 @@ Clause_p ClauseSetSubsumesClause(ClauseSet_p set, Clause_p sub_candidate)
 
    PERF_CTR_ENTRY(SetSubsumeTimer);
    assert(sub_candidate->weight == ClauseStandardWeight(sub_candidate));
-   if(set->clauseset_indexes->fvindex)
+   if(set->fvindex)
    {
       FreqVector_p vec = OptimizedVarFreqVectorCompute(sub_candidate,
-                                                       set->clauseset_indexes->fvindex->perm_vector,
-                                                       set->clauseset_indexes->fvindex->cspec);
-      res =  clause_set_subsumes_clause_indexed(set->clauseset_indexes->fvindex->index, vec, 0);
+                                                       set->fvindex->perm_vector,
+                                                       set->fvindex->cspec);
+      res =  clause_set_subsumes_clause_indexed(set->fvindex->index, vec, 0);
       FreqVectorFree(vec);
       PERF_CTR_EXIT(SetSubsumeTimer);
       return res;
@@ -1549,9 +1549,9 @@ long ClauseSetFindFVSubsumedClauses(ClauseSet_p set,
    PERF_CTR_ENTRY(SetSubsumeTimer);
    assert(subsumer->clause->weight == ClauseStandardWeight(subsumer->clause));
 
-   if(set->clauseset_indexes->fvindex)
+   if(set->fvindex)
    {
-      clauseset_find_subsumed_clauses_indexed(set->clauseset_indexes->fvindex->index,
+      clauseset_find_subsumed_clauses_indexed(set->fvindex->index,
                                               subsumer, 0, res);
    }
    else
@@ -1585,9 +1585,9 @@ Clause_p ClauseSetFindFirstFVSubsumedClause(ClauseSet_p set,
    PERF_CTR_ENTRY(SetSubsumeTimer);
    assert(subsumer->clause->weight == ClauseStandardWeight(subsumer->clause));
 
-   if(set->clauseset_indexes->fvindex)
+   if(set->fvindex)
    {
-      res = clauseset_find_first_subsumed_clause_indexed(set->clauseset_indexes->fvindex->index,
+      res = clauseset_find_first_subsumed_clause_indexed(set->fvindex->index,
                                                    subsumer, 0);
    }
    else
@@ -1622,7 +1622,7 @@ long ClauseSetFindSubsumedClauses(ClauseSet_p set,
 
    assert(subsumer->weight == ClauseStandardWeight(subsumer));
 
-   pclause = FVIndexPackClause(subsumer, set->clauseset_indexes->fvindex);
+   pclause = FVIndexPackClause(subsumer, set->fvindex);
 
    found = ClauseSetFindFVSubsumedClauses(set, pclause, res);
 
@@ -1654,7 +1654,7 @@ Clause_p ClauseSetFindFirstSubsumedClause(ClauseSet_p set,
 
    assert(subsumer->weight == ClauseStandardWeight(subsumer));
 
-   pclause = FVIndexPackClause(subsumer, set->clauseset_indexes->fvindex);
+   pclause = FVIndexPackClause(subsumer, set->fvindex);
 
    res = ClauseSetFindFirstFVSubsumedClause(set, pclause);
 
@@ -1682,10 +1682,9 @@ Clause_p ClauseSetFindFirstSubsumedClause(ClauseSet_p set,
 Clause_p ClauseSetFindFVVariantClause(ClauseSet_p set,
                                       FVPackedClause_p clause)
 {
-   assert(set->clauseset_indexes);
-   assert(set->clauseset_indexes->fvindex);
+   assert(set->fvindex);
 
-   return clauseset_find_variant_clause_indexed(set->clauseset_indexes->fvindex->index,
+   return clauseset_find_variant_clause_indexed(set->fvindex->index,
                                                 clause, 0);
 }
 
@@ -1711,7 +1710,7 @@ Clause_p ClauseSetFindVariantClause(ClauseSet_p set,
 
    assert(clause->weight == ClauseStandardWeight(clause));
 
-   pclause = FVIndexPackClause(clause, set->clauseset_indexes->fvindex);
+   pclause = FVIndexPackClause(clause, set->fvindex);
 
    res = ClauseSetFindFVVariantClause(set, pclause);
 

--- a/CLAUSES/ccl_unit_simplify.c
+++ b/CLAUSES/ccl_unit_simplify.c
@@ -80,13 +80,13 @@ SimplifyRes FindTopSimplifyingUnit(ClauseSet_p units, Term_p t1,
 
    assert(TermStandardWeight(t1) == TermWeight(t1,DEFAULT_VWEIGHT,DEFAULT_FWEIGHT));
    assert(TermStandardWeight(t2) == TermWeight(t2,DEFAULT_VWEIGHT,DEFAULT_FWEIGHT));
-   assert(units && units->clauseset_indexes);
-   assert(units->clauseset_indexes->demod_index);
+   assert(units);
+   assert(units->demod_index);
 
-   PDTreeSearchInit(units->clauseset_indexes->demod_index, t1, PDTREE_IGNORE_NF_DATE, false);
+   PDTreeSearchInit(units->demod_index, t1, PDTREE_IGNORE_NF_DATE, false);
 
    MatchRes_p mi;
-   while((mi = PDTreeFindNextDemodulator(units->clauseset_indexes->demod_index, subst)))
+   while((mi = PDTreeFindNextDemodulator(units->demod_index, subst)))
    {
       pos = mi->pos;
 
@@ -102,7 +102,7 @@ SimplifyRes FindTopSimplifyingUnit(ClauseSet_p units, Term_p t1,
         break;
       }
    }
-   PDTreeSearchExit(units->clauseset_indexes->demod_index);
+   PDTreeSearchExit(units->demod_index);
    SubstDelete(subst);
    return res;
 }
@@ -130,13 +130,13 @@ SimplifyRes FindSignedTopSimplifyingUnit(ClauseSet_p units, Term_p t1,
 
    assert(TermStandardWeight(t1) == TermWeight(t1,DEFAULT_VWEIGHT,DEFAULT_FWEIGHT));
    assert(TermStandardWeight(t2) == TermWeight(t2,DEFAULT_VWEIGHT,DEFAULT_FWEIGHT));
-   assert(units && units->clauseset_indexes);
-   assert(units->clauseset_indexes->demod_index);
+   assert(units);
+   assert(units->demod_index);
 
-   PDTreeSearchInit(units->clauseset_indexes->demod_index, t1, PDTREE_IGNORE_NF_DATE, false);
+   PDTreeSearchInit(units->demod_index, t1, PDTREE_IGNORE_NF_DATE, false);
 
    MatchRes_p mi;
-   while((mi = PDTreeFindNextDemodulator(units->clauseset_indexes->demod_index, subst)))
+   while((mi = PDTreeFindNextDemodulator(units->demod_index, subst)))
    {
       pos = mi->pos;
       if(EQUIV(EqnIsPositive(pos->literal), sign)
@@ -153,7 +153,7 @@ SimplifyRes FindSignedTopSimplifyingUnit(ClauseSet_p units, Term_p t1,
       }
       MatchResFree(mi);
    }
-   PDTreeSearchExit(units->clauseset_indexes->demod_index);
+   PDTreeSearchExit(units->demod_index);
    SubstDelete(subst);
    return res;
 }
@@ -288,7 +288,7 @@ bool ClauseSimplifyWithUnitSet(Clause_p clause, ClauseSet_p unit_set,
    SimplifyRes res;
 
    assert(clause);
-   assert(unit_set && unit_set->clauseset_indexes);
+   assert(unit_set);
    assert(how);
 
    handle = &(clause->literals);

--- a/CLAUSES/ccl_unitclause_index.h
+++ b/CLAUSES/ccl_unitclause_index.h
@@ -27,7 +27,7 @@ Copyright 2019-2020 by the author.
 /*                    Data type declarations                           */
 /*---------------------------------------------------------------------*/
 
-typedef struct unitterm_index_cell 
+typedef struct unitclause_index_cell 
 {
    Term_p termL;
    PTree_p right;
@@ -39,8 +39,10 @@ typedef FPIndex_p UnitclauseIndex_p;
 /*                Exported Functions and Variables                     */
 /*---------------------------------------------------------------------*/
 
+void UnitclauseIndexFreeWrapper(void *junk);
+
 #define UnitClauseIndexCellAlloc() (UnitClauseIndexCell*)SizeMalloc(sizeof(UnitClauseIndexCell))
-#define UnitClauseIndexCellFree(junk) SizeFree(junk, sizeof(UnitClauseIndexCell))
+#define UnitClauseIndexCellFreeRaw(junk) SizeFree(junk, sizeof(UnitClauseIndexCell))
 
 bool UnitclauseIndexDeleteClause(UnitclauseIndex_p index, Clause_p clause);
 void UnitclauseIndexDeleteTerm(PObjTree_p *root, Term_p lterm);
@@ -54,8 +56,7 @@ bool UnitclauseIndexInsert(UnitclauseIndex_p index, Term_p lterm, Term_p rterm);
 /*                         Internal Functions                          */
 /*---------------------------------------------------------------------*/
 
-UnitClauseIndexCell_p UnitClauseIndexAlloc(Term_p termL);
-void UnitClauseIndexNodeFree(UnitClauseIndexCell_p junk);
+void UnitClauseIndexCellFree(UnitClauseIndexCell_p junk);
 int CmpUnitClauseIndexCells(const void* cell1, const void* cell2);
 UnitClauseIndexCell_p UnitclauseInsert(PObjTree_p *root, Term_p lterm);
 

--- a/CONTROL/cco_forward_contraction.c
+++ b/CONTROL/cco_forward_contraction.c
@@ -106,7 +106,7 @@ static FVPackedClause_p forward_contract_keep(ProofState_p state, ProofControl_p
       assert(!ClauseIsTrivial(clause));
 
       clause->weight = ClauseStandardWeight(clause);
-      pclause = FVIndexPackClause(clause, state->processed_non_units->clauseset_indexes->fvindex);
+      pclause = FVIndexPackClause(clause, state->processed_non_units->fvindex);
 
       if(clause->pos_lit_no)
       {
@@ -138,7 +138,7 @@ static FVPackedClause_p forward_contract_keep(ProofState_p state, ProofControl_p
                                             clause);
          ClauseSubsumeOrderSortLits(clause);
          pclause = FVIndexPackClause(FVUnpackClause(pclause),
-                                state->processed_non_units->clauseset_indexes->fvindex);
+                                state->processed_non_units->fvindex);
 
       }
    }
@@ -150,7 +150,7 @@ static FVPackedClause_p forward_contract_keep(ProofState_p state, ProofControl_p
          return FVIndexPackClause(clause, NULL);
       }
       clause->weight = ClauseStandardWeight(clause);
-      pclause = FVIndexPackClause(clause, state->processed_non_units->clauseset_indexes->fvindex);
+      pclause = FVIndexPackClause(clause, state->processed_non_units->fvindex);
    }
    ClauseDelProp(clause, CPIsOriented);
    DoLiteralSelection(control, clause);
@@ -314,7 +314,7 @@ Clause_p ForwardContractSet(ProofState_p state, ProofControl_p
 
    assert(state);
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = set->anchor->succ;
    while(handle != set->anchor)
@@ -363,7 +363,7 @@ void ClauseSetReweight(HCB_p heuristic, ClauseSet_p set)
 
    assert(heuristic);
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
 
    ClauseSetRemoveEvaluations(set);
@@ -410,7 +410,7 @@ Clause_p ForwardContractSetReweight(ProofState_p state, ProofControl_p
 
    assert(state);
    assert(set);
-   assert(!set->clauseset_indexes->demod_index);
+   assert(!set->demod_index);
 
    handle = ForwardContractSet(state, control, set,
                                non_unit_subsumption, level,

--- a/CONTROL/cco_proofproc.c
+++ b/CONTROL/cco_proofproc.c
@@ -387,8 +387,7 @@ void check_watchlist(GlobalIndices_p indices, ClauseSet_p watchlist,
 
    if(watchlist)
    {
-      // TODO: If clause is of type unit consult the new PDTIndex as an index instead of the FVIndex.
-      pclause = FVIndexPackClause(clause, watchlist->clauseset_indexes->fvindex);
+      pclause = FVIndexPackClause(clause, watchlist->fvindex);
       // printf("# check_watchlist(%p)...\n", indices);
       ClauseSubsumeOrderSortLits(clause);
       // assert(ClauseIsSubsumeOrdered(clause));
@@ -1287,17 +1286,17 @@ void fvi_param_init(ProofState_p state, ProofControl_p control)
                             control->fvi_parms.eliminate_uninformative);
    if(control->fvi_parms.cspec.features != FVINoFeatures)
    {
-      state->processed_non_units->clauseset_indexes->fvindex =
+      state->processed_non_units->fvindex =
          FVIAnchorAlloc(cspec, PermVectorCopy(perm));
-      state->processed_pos_rules->clauseset_indexes->fvindex =
+      state->processed_pos_rules->fvindex =
          FVIAnchorAlloc(cspec, PermVectorCopy(perm));
-      state->processed_pos_eqns->clauseset_indexes->fvindex =
+      state->processed_pos_eqns->fvindex =
          FVIAnchorAlloc(cspec, PermVectorCopy(perm));
-      state->processed_neg_units->clauseset_indexes->fvindex =
+      state->processed_neg_units->fvindex =
          FVIAnchorAlloc(cspec, PermVectorCopy(perm));
       if(state->watchlist)
       {
-         state->watchlist->clauseset_indexes->fvindex =
+         state->watchlist->fvindex =
             FVIAnchorAlloc(cspec, PermVectorCopy(perm));
          //ClauseSetNewTerms(state->watchlist, state->terms);
       }
@@ -1314,7 +1313,7 @@ void fvi_param_init(ProofState_p state, ProofControl_p control)
                                            symbols,
                                            0,0,0,
                                            0,0,0);
-   state->definition_store->def_clauses->clauseset_indexes->fvindex =
+   state->definition_store->def_clauses->fvindex =
       FVIAnchorAlloc(state->def_store_cspec, perm);
 }
 
@@ -1406,11 +1405,13 @@ void ProofStateInit(ProofState_p state, ProofControl_p control)
       }
    }
 
+   // TODO: Heuristic funtion?
    GlobalIndicesInit(&(state->gindices),
                      state->signature,
                      control->heuristic_parms.rw_bw_index_type,
                      control->heuristic_parms.pm_from_index_type,
-                     control->heuristic_parms.pm_into_index_type);
+                     control->heuristic_parms.pm_into_index_type,
+                     control->heuristic_parms.rw_bw_index_type);
 
 }
 

--- a/EXTERNAL/cex_csscpa.c
+++ b/EXTERNAL/cex_csscpa.c
@@ -216,8 +216,8 @@ CSSCPAState_p CSSCPAStateAlloc(void)
    handle->pos_units = ClauseSetAlloc();
    handle->neg_units = ClauseSetAlloc();
    handle->non_units = ClauseSetAlloc();
-   handle->pos_units->clauseset_indexes->demod_index = PDTreeAlloc(handle->terms);
-   handle->neg_units->clauseset_indexes->demod_index = PDTreeAlloc(handle->terms);
+   handle->pos_units->demod_index = PDTreeAlloc(handle->terms);
+   handle->neg_units->demod_index = PDTreeAlloc(handle->terms);
    handle->literals  = 0;
    handle->clauses   = 0;
    handle->weight    = 0;

--- a/PROVER/eground.c
+++ b/PROVER/eground.c
@@ -476,7 +476,7 @@ int main(int argc, char* argv[])
    perm = PermVectorCompute(clauses,
                             cspec,
                             false);
-   def_store->def_clauses->clauseset_indexes->fvindex = FVIAnchorAlloc(cspec, perm);
+   def_store->def_clauses->fvindex = FVIAnchorAlloc(cspec, perm);
 
    SpecFeaturesCompute(&features, clauses, sig);
 

--- a/PROVER/enormalizer.c
+++ b/PROVER/enormalizer.c
@@ -521,7 +521,7 @@ int main(int argc, char* argv[])
    FormulaSetFree(f_ax_archive);
 
    demodulators[0] = ClauseSetAlloc();
-   demodulators[0]->clauseset_indexes->demod_index = PDTreeAlloc(terms);
+   demodulators[0]->demod_index = PDTreeAlloc(terms);
    GCRegisterClauseSet(collector, demodulators[0]);
 
    build_rw_system(demodulators[0], clauses);

--- a/PROVER/eprover.c
+++ b/PROVER/eprover.c
@@ -496,11 +496,14 @@ int main(int argc, char* argv[])
    PCLFullTerms = pcl_full_terms; /* Preprocessing always uses full
                                      terms, so we set the flag for
                                      the main proof search only now! */
+
+   // TODO: Determine wether no index holds here.
    GlobalIndicesInit(&(proofstate->wlindices),
                      proofstate->signature,
                      proofcontrol->heuristic_parms.rw_bw_index_type,
                      "NoIndex",
-                     "NoIndex");
+                     "NoIndex",
+                     "FP6M");
    //printf("Alive (1)!\n");
 
    ProofStateInit(proofstate, proofcontrol);


### PR DESCRIPTION
This closes issue #3 

The changes are numerous, but most importantly:
1. The clause sets indexes are back to their original state because the new unitclause_index (as a fingerprint index) better fitted within the global_indicies (access to FingerPrintFunctions etc.).
2. ClausetIndexes are therefore unused now and might be deleted in the future (The value of having an index structure that only uses two indices of all of the indices in E is questionable). 